### PR TITLE
Fixes and features to enable jules::as_matrix(base_dataframe)

### DIFF
--- a/jules/core/type.hpp
+++ b/jules/core/type.hpp
@@ -27,10 +27,10 @@ template <typename T>
 struct StringConvertible<T, std::enable_if_t<meta::compiles<T, detail::to_string_expr>::value>> : std::true_type {
 };
 
-template <typename T, typename = void> struct Signed : std::false_type {};
+template <typename T, typename = void> struct Signed : std::false_type {
+};
 
-template <typename T>
-struct Signed<T, std::enable_if_t<std::numeric_limits<T>::is_signed>> : std::true_type {
+template <typename T> struct Signed<T, std::enable_if_t<std::numeric_limits<T>::is_signed>> : std::true_type {
 };
 
 /// Standard numeric type.
@@ -88,7 +88,8 @@ struct string_rule {
     return std::to_string(value);
   }
 
-  template <typename U, typename = meta::fallback<StringConvertible<const U&>>, typename = std::enable_if_t<std::is_convertible<const U&, type>::value>>
+  template <typename U, typename = meta::fallback<StringConvertible<const U&>>,
+            typename = std::enable_if_t<std::is_convertible<const U&, type>::value>>
   static auto coerce_from(const U& value) -> type
   {
     return value;
@@ -97,7 +98,7 @@ struct string_rule {
 
 /// Coercion rules for [index type](standardese://jules::index_t/).
 /// \module Coercion Rules
-struct index_rule  {
+struct index_rule {
   using type = index_t;
 
   static auto coerce_from(const string& value) -> type { return std::stoul(value); }
@@ -109,7 +110,8 @@ struct index_rule  {
     return value;
   }
 
-  template <typename U, typename = meta::fallback<Signed<U>>, typename = std::enable_if_t<std::is_convertible<const U&, type>::value>>
+  template <typename U, typename = meta::fallback<Signed<U>>,
+            typename = std::enable_if_t<std::is_convertible<const U&, type>::value>>
   static auto coerce_from(const U& value) -> type
   {
     return value;
@@ -126,7 +128,7 @@ struct integer_rule : default_rule<integer> {
 
 /// Coercion rules for [unsigned type](standardese://jules::uinteger/).
 /// \module Coercion Rules
-struct uinteger_rule  {
+struct uinteger_rule {
   using type = uinteger;
 
   static auto coerce_from(const string& value) -> type
@@ -144,7 +146,8 @@ struct uinteger_rule  {
     return value;
   }
 
-  template <typename U, typename = meta::fallback<Signed<U>>, typename = std::enable_if_t<std::is_convertible<const U&, type>::value>>
+  template <typename U, typename = meta::fallback<Signed<U>>,
+            typename = std::enable_if_t<std::is_convertible<const U&, type>::value>>
   static auto coerce_from(const U& value) -> type
   {
     return value;
@@ -180,24 +183,6 @@ using coercion_rules = base_coercion_rules<numeric_rule, string_rule, index_rule
 
 namespace detail
 {
-
-// Trivial/Non-trivial dispatch
-
-struct trivial_tag {
-};
-
-struct non_trivial_tag {
-};
-
-template <typename T, typename = void> struct trivial_dispatch_helper {
-  using type = non_trivial_tag;
-};
-
-template <typename T> struct trivial_dispatch_helper<T, std::enable_if_t<std::is_trivial<T>::value>> {
-  using type = trivial_tag;
-};
-
-template <typename T> auto trivial_dispatch() { return typename trivial_dispatch_helper<T>::type{}; }
 
 // Tag type utility
 

--- a/jules/core/type.hpp
+++ b/jules/core/type.hpp
@@ -127,7 +127,15 @@ struct in_place_t {
   constexpr explicit in_place_t() = default;
 };
 
-static constexpr in_place_t in_place{};
+static constexpr auto in_place = in_place_t{};
+
+// Non-initialized construction tag
+
+struct uninitialized_t {
+  constexpr explicit uninitialized_t() = default;
+};
+
+static constexpr auto uninitialized = uninitialized_t{};
 
 // Arithmetic rules
 

--- a/jules/dataframe/dataframe.hpp
+++ b/jules/dataframe/dataframe.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Filipe Verri <filipeverri@gmail.com>
+// Copyright (c) 2016-2017 Filipe Verri <filipeverri@gmail.com>
 
 #ifndef JULES_DATAFRAME_DATAFRAME_H
 #define JULES_DATAFRAME_DATAFRAME_H

--- a/jules/dataframe/detail/column_model.hpp
+++ b/jules/dataframe/detail/column_model.hpp
@@ -109,8 +109,7 @@ protected:
 template <typename T, typename U, typename Coercion, std::size_t I>
 class specific_concrete_coercion<
   T, U, Coercion, I,
-  std::enable_if_t<std::is_same<decltype(Coercion::template rule<I>::coerce_from(std::declval<T>())), U>::value &&
-                   !std::is_convertible<T, U>::value>>
+  std::enable_if_t<std::is_same<decltype(Coercion::template rule<I>::coerce_from(std::declval<T>())), U>::value>>
 {
 private:
   using type = typename Coercion::template type<I>;
@@ -125,30 +124,6 @@ protected:
     result->reserve(end - begin);
     std::transform(begin, end, std::back_inserter(*result),
                    [](const T& value) { return Coercion::template rule<I>::coerce_from(value); });
-
-    return column_interface_ptr{move_ptr(result)};
-  }
-
-  constexpr bool can_coerce_(tag<type>) const { return true; }
-};
-
-// Automatic coercion rules.  If it is possible to convert from T to type using a
-// implicit method, this class is instantiated.
-template <typename T, typename U, typename Coercion, std::size_t I>
-class specific_concrete_coercion<T, U, Coercion, I, std::enable_if_t<std::is_convertible<T, U>::value>>
-{
-private:
-  using type = typename Coercion::template type<I>;
-  using column_interface_ptr = std::unique_ptr<column_interface<Coercion>>;
-
-protected:
-  template <typename Iter> column_interface_ptr coerce_(Iter begin, Iter end, tag<type>) const
-  {
-    auto result = new column_model<type, Coercion>;
-    JULES_DEFER(delete result);
-
-    result->reserve(end - begin);
-    std::transform(begin, end, std::back_inserter(*result), [](const T& value) -> type { return value; });
 
     return column_interface_ptr{move_ptr(result)};
   }

--- a/jules/dataframe/detail/common.hpp
+++ b/jules/dataframe/detail/common.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2017 Filipe Verri <filipeverri@gmail.com>
+
+#ifndef JULES_DATAFRAME_DETAIL_COMMON_H
+#define JULES_DATAFRAME_DETAIL_COMMON_H
+
+namespace jules
+{
+
+template <typename C> class base_column;
+template <typename C> class base_dataframe;
+
+} // namespace jules
+
+#endif // JULES_DATAFRAME_DETAIL_COMMON_H

--- a/jules/dataframe/numeric.hpp
+++ b/jules/dataframe/numeric.hpp
@@ -1,9 +1,11 @@
+// Copyright (c) 2016-2017 Filipe Verri <filipeverri@gmail.com>
+
 #ifndef JULES_DATAFRAME_NUMERIC_H
 #define JULES_DATAFRAME_NUMERIC_H
 
 #include <jules/array/array.hpp>
 #include <jules/array/contiguous_array.hpp>
-#include <jules/dataframe/column.hpp>
+#include <jules/dataframe/detail/common.hpp>
 
 namespace jules
 {
@@ -23,6 +25,8 @@ template <typename T, typename C> auto to_column(base_column<C>&& column) -> bas
 
 template <typename T, typename C> auto to_view(base_column<C>& column) -> contiguous_array<T, 1>
 {
+  if (column.elements_type() != typeid(T))
+    column.template coerce<T>();
   return {column.template data<T>(), column.size()};
 }
 
@@ -45,6 +49,30 @@ template <typename T, typename C> auto to_vector(const base_column<C>& column) -
 
   auto data = column.template data<T>();
   return {data, data + size};
+}
+
+template <typename T, typename C> auto to_matrix(const base_dataframe<C>& df) -> base_array<T, 2>
+{
+  auto temp = std::vector<base_column<C>>();
+  auto data_vector = std::vector<contiguous_array<const T, 1>>();
+
+  for (auto i = 0u; i < df.column_count(); ++i) {
+    const auto& column = df.at(i).column;
+    if (column.elements_type() == typeid(T)) {
+      data_vector.push_back(to_view<T>(column));
+    } else {
+      temp.push_back(to_column<T>(column));
+      data_vector.push_back(to_view<T>(temp.back()));
+    }
+  }
+
+  auto result = base_array<T, 2>(uninitialized, df.row_count(), df.column_count());
+  auto it = result.begin();
+  for (const auto& data : data_vector)
+    for (const T& value : data)
+      ::new (static_cast<void*>(it++)) T(value);
+
+  return result;
 }
 
 } // namespace jules

--- a/test/array/matrix.cpp
+++ b/test/array/matrix.cpp
@@ -15,6 +15,12 @@ TEST_CASE("Matrix tutorial", "[array]")
     CHECK(empty.begin() == empty.end());
     CHECK(empty.cbegin() == empty.cend());
 
+    // Uninitialized vs initialized
+    auto uninit = jules::matrix<>(jules::uninitialized, 3u, 3u);
+    auto init = jules::matrix<>(3u, 3u);
+
+    CHECK(all(init == jules::numeric{}));
+
     // Constructors with size and optional default value.
     auto all_same1 = jules::matrix<long>(3l, 4u, 4u);
     auto all_same2 = jules::matrix<long>(4u, 4u);

--- a/test/array/vector.cpp
+++ b/test/array/vector.cpp
@@ -15,6 +15,12 @@ TEST_CASE("Vector tutorial", "[array]")
     CHECK(empty.begin() == empty.end());
     CHECK(empty.cbegin() == empty.cend());
 
+    // Uninitialized vs initialized
+    auto uninit = jules::vector<>(jules::uninitialized, 10u);
+    auto init = jules::vector<>(10u);
+
+    CHECK(all(init == jules::numeric{}));
+
     // Constructors with size and optional default value.
     auto all_same1 = jules::vector<long>(3l, 10u);
     auto all_same2 = jules::vector<long>(10u);

--- a/test/dataframe/column_model.cpp
+++ b/test/dataframe/column_model.cpp
@@ -62,3 +62,103 @@ TEST_CASE("Column model", "[dataframe]")
   auto clone = scolumn->clone();
   CHECK(clone->elements_type() == scolumn->elements_type());
 }
+
+TEST_CASE("Column model sanity conversions", "[dataframe]")
+{
+  using namespace jules;
+  using namespace jules::detail;
+  using namespace std::string_literals;
+  using column_ptr = std::unique_ptr<column_interface<coercion_rules>>;
+
+  // Default types: string, numeric, integer, uinteger, index_t
+
+  struct Foo {
+    operator string() const { return "foo"; }
+    operator double() const { return 0.0; }
+  };
+
+  struct Bar {
+  };
+
+  const auto str_column = column_ptr{new column_model<string, coercion_rules>{"1"s, "-1"s}};
+  const auto num_column = column_ptr{new column_model<numeric, coercion_rules>};
+  const auto ind_column = column_ptr{new column_model<index_t, coercion_rules>};
+  const auto int_column = column_ptr{new column_model<integer, coercion_rules>};
+  const auto uns_column = column_ptr{new column_model<uinteger, coercion_rules>};
+  const auto foo_column = column_ptr{new column_model<Foo, coercion_rules>};
+  const auto bar_column = column_ptr{new column_model<Bar, coercion_rules>};
+  const auto flt_column = column_ptr{new column_model<float, coercion_rules>{1.0f, -1.0f}};
+
+  // String:
+  //    From everything that works with std::to_string
+  //    From everything implictly converted to string
+  //    To every default type
+  //== from ==//
+  CHECK(str_column->can_coerce<string>());
+  CHECK(num_column->can_coerce<string>());
+  CHECK(ind_column->can_coerce<string>());
+  CHECK(int_column->can_coerce<string>());
+  CHECK(uns_column->can_coerce<string>());
+  CHECK(foo_column->can_coerce<string>());
+  CHECK(!bar_column->can_coerce<string>());
+  CHECK(flt_column->can_coerce<string>());
+  //== to ==//
+  CHECK(str_column->can_coerce<string>());
+  CHECK(str_column->can_coerce<numeric>());
+  CHECK(str_column->can_coerce<index_t>());
+  CHECK(str_column->can_coerce<integer>());
+  CHECK(str_column->can_coerce<uinteger>());
+  CHECK(!str_column->can_coerce<Foo>());
+  CHECK(!str_column->can_coerce<Bar>());
+  CHECK(!str_column->can_coerce<float>());
+
+  // Numeric:
+  //    From string
+  //    From everything implictly converted to double
+  //    To every default type
+  //== from ==//
+  CHECK(str_column->can_coerce<numeric>());
+  CHECK(num_column->can_coerce<numeric>());
+  CHECK(ind_column->can_coerce<numeric>());
+  CHECK(int_column->can_coerce<numeric>());
+  CHECK(uns_column->can_coerce<numeric>());
+  CHECK(foo_column->can_coerce<numeric>());
+  CHECK(!bar_column->can_coerce<numeric>());
+  CHECK(flt_column->can_coerce<numeric>());
+  //== to ==//
+  CHECK(num_column->can_coerce<string>());
+  CHECK(num_column->can_coerce<numeric>());
+  CHECK(num_column->can_coerce<index_t>());
+  CHECK(num_column->can_coerce<integer>());
+  CHECK(num_column->can_coerce<uinteger>());
+  CHECK(!num_column->can_coerce<Foo>());
+  CHECK(!num_column->can_coerce<Bar>());
+  CHECK(!num_column->can_coerce<float>());
+
+  // Index:
+  //    From string
+  //    From everything implictly converted to std::size_t
+  //      If signed, the value must be positive.
+  //    To every default type
+  //== from ==//
+  CHECK(str_column->can_coerce<index_t>());
+  CHECK(num_column->can_coerce<index_t>());
+  CHECK(ind_column->can_coerce<index_t>());
+  CHECK(int_column->can_coerce<index_t>());
+  CHECK(uns_column->can_coerce<index_t>());
+  CHECK(foo_column->can_coerce<index_t>());
+  CHECK(!bar_column->can_coerce<index_t>());
+  CHECK(flt_column->can_coerce<index_t>());
+  //== to ==//
+  CHECK(ind_column->can_coerce<string>());
+  CHECK(ind_column->can_coerce<numeric>());
+  CHECK(ind_column->can_coerce<index_t>());
+  CHECK(ind_column->can_coerce<integer>());
+  CHECK(ind_column->can_coerce<uinteger>());
+  CHECK(!ind_column->can_coerce<Foo>());
+  CHECK(!ind_column->can_coerce<Bar>());
+  CHECK(!ind_column->can_coerce<float>());
+
+  CHECK_THROWS(str_column->downcast<index_t>().size());
+  CHECK_THROWS(flt_column->downcast<index_t>().size());
+}

--- a/test/dataframe/dataframe.cpp
+++ b/test/dataframe/dataframe.cpp
@@ -312,7 +312,7 @@ TEST_CASE("Reading and writing a well-formed dataframe", "[dataframe]")
 
   std::stringstream os2;
 
-  dataframe{{"y", {0, 3}}, {"x", {1, 4}}, {"z", {2, 5}}}.write(os2);
+  dataframe{{"y", {0.0, 3.0}}, {"x", {1.0, 4.0}}, {"z", {2.0, 5.0}}}.write(os2);
   CHECK(data == os2.str());
 
   const auto cols = df.names();

--- a/test/dataframe/dataframe.cpp
+++ b/test/dataframe/dataframe.cpp
@@ -235,7 +235,7 @@ TEST_CASE("Reading matrix of integers", "[dataframe]")
   opts.header = false;
 
   std::stringstream stream;
-  constexpr auto N = 10u;
+  constexpr auto N = 3u;
   for (auto i = 0u; i < N; ++i) {
     for (auto j = 0u; j < N; ++j) {
       stream << (i * N + j) << "\t";
@@ -273,6 +273,10 @@ TEST_CASE("Reading matrix of integers", "[dataframe]")
 
   CHECK(idf.column_count() == N);
   CHECK(idf.row_count() == N);
+
+  // Converting to matrix
+  auto imatrix = jules::to_matrix<int>(idf);
+  CHECK(all(imatrix == jules::matrix<int>{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}));
 }
 
 TEST_CASE("Reading an inconsistent dataframe", "[dataframe]")

--- a/test/dataframe/dataframe.cpp
+++ b/test/dataframe/dataframe.cpp
@@ -218,13 +218,15 @@ TEST_CASE("Reading a dataframe", "[dataframe]")
 
 TEST_CASE("Reading matrix of integers", "[dataframe]")
 {
-  struct my_integer_rules {
-    using type = int;
+  struct my_integer_rules : jules::default_rule<int> {
+    using jules::default_rule<int>::type;
+    using jules::default_rule<int>::coerce_from;
     static auto coerce_from(const jules::string& value) -> type { return std::stoi(value); }
   };
 
-  struct my_string_rules {
-    using type = jules::string;
+  struct my_string_rules : jules::default_rule<std::string> {
+    using jules::default_rule<std::string>::type;
+    using jules::default_rule<std::string>::coerce_from;
     static auto coerce_from(int value) -> type { return std::to_string(value); }
   };
 


### PR DESCRIPTION
- [x] Uninitialized array construction.
- [x] Better (and consistent) coercion rules
    - [x] Add index_t, int and unsigned
    - [x] Disable implicit conversions
- [x] Array allocator needs some fixes (issue #17)

Possible extra:
- [ ] Implement `jules::which`