### PR TITLE
Using const_vector instead of std::vector

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "*.cpp"
+  - "test"

--- a/jules/array/all.hpp
+++ b/jules/array/all.hpp
@@ -5,6 +5,7 @@
 
 #include <jules/array/array.hpp>
 #include <jules/array/binary_expr_array.hpp>
+#include <jules/array/contiguous_array.hpp>
 #include <jules/array/functional.hpp>
 #include <jules/array/ind_array.hpp>
 #include <jules/array/io.hpp>

--- a/jules/array/array.hpp
+++ b/jules/array/array.hpp
@@ -8,6 +8,7 @@
 #include <jules/array/detail/common.hpp>
 #include <jules/array/ref_array.hpp>
 #include <jules/base/async.hpp>
+#include <jules/base/const_vector.hpp>
 #include <jules/base/numeric.hpp>
 #include <jules/core/meta.hpp>
 #include <jules/core/type.hpp>
@@ -526,13 +527,13 @@ public:
 
   /// \group Indexing
   /// Optimized indirect indexing from temporary indexes.
-  auto operator()(std::vector<index_t>&& indexes) -> ind_array<value_type, 1>
+  auto operator()(const_vector<index_t> indexes) -> ind_array<value_type, 1>
   {
     return {this->data_, indexes.size(), std::move(indexes)};
   }
 
   /// \group Indexing
-  auto operator()(std::vector<index_t>&& indexes) const -> ind_array<const value_type, 1>
+  auto operator()(const_vector<index_t> indexes) const -> ind_array<const value_type, 1>
   {
     return {this->data_, indexes.size(), std::move(indexes)};
   }

--- a/jules/array/array.hpp
+++ b/jules/array/array.hpp
@@ -57,10 +57,10 @@ public:
   /// (6) Signed integer type that can store differences between sizes.
   static constexpr auto order = N;
 
-  /// \group member_types Class Types and Constants
+  /// \group member_types
   using value_type = T;
 
-  /// \group member_types Class Types and Constants
+  /// \group member_types
   using iterator = value_type*;
 
   /// \group member_types

--- a/jules/array/ind_array.hpp
+++ b/jules/array/ind_array.hpp
@@ -117,7 +117,7 @@ public:
   template <typename... Args> auto operator()(Args&&... args) -> detail::slice_request<ind_array<T, N>, Args...>
   {
     auto slice = detail::default_slicing(descriptor_, std::forward<Args>(args)...);
-    auto indexes = std::vector<index_t>();
+    auto indexes = typename vector_type::container_type();
 
     indexes.reserve(slice.size());
     for (auto j : slice)
@@ -145,7 +145,7 @@ public:
   template <typename... Args> auto operator()(Args&&... args) const -> detail::slice_request<ind_array<const T, N>, Args...>
   {
     auto slice = detail::default_slicing(descriptor_, std::forward<Args>(args)...);
-    auto indexes = std::vector<index_t>();
+    auto indexes = typename vector_type::container_type();
 
     indexes.reserve(slice.size());
     for (auto j : slice)
@@ -182,7 +182,7 @@ private:
   auto row(index_t i) const
   {
     auto extents = std::array<index_t, N - 1>();
-    auto indexes = std::vector<index_t>();
+    auto indexes = typename vector_type::container_type();
     indexes.reserve(size() / row_count());
 
     std::copy(std::begin(extents()) + 1, std::end(extents()), std::begin(extents));
@@ -299,7 +299,7 @@ public:
     return {data_, slicing.first.extent, std::move(indexes)};
   }
 
-  auto operator()(std::vector<index_t> indexes) -> ind_array<T, 1>
+  auto operator()(typename vector_type::container_type indexes) -> ind_array<T, 1>
   {
     inplace_map_indexes(indexes);
     return {this->data_, indexes.size(), std::move(indexes)};
@@ -324,7 +324,7 @@ public:
     return {data_, slicing.first.extent, std::move(indexes)};
   }
 
-  auto operator()(std::vector<index_t> indexes) const -> ind_array<const T, 1>
+  auto operator()(typename vector_type::container_type indexes) const -> ind_array<const T, 1>
   {
     inplace_map_indexes(indexes);
     return {this->data_, indexes.size(), std::move(indexes)};
@@ -357,14 +357,14 @@ public:
 private:
   template <typename Range> auto map_indexes(const Range& rng) const
   {
-    auto indexes = std::vector<index_t>();
+    auto indexes = typename vector_type::container_type();
     indexes.reserve(rng.size());
     for (index_t j : rng)
       indexes.push_back(indexes_[j]);
     return indexes;
   }
 
-  auto inplace_map_indexes(std::vector<index_t>& indexes) const
+  auto inplace_map_indexes(typename vector_type::container_type& indexes) const
   {
     for (auto& index : indexes)
       index = indexes_[index];

--- a/jules/array/ind_array.hpp
+++ b/jules/array/ind_array.hpp
@@ -139,7 +139,7 @@ public:
     auto slicing = detail::indirect_slicing(descriptor_, std::forward<Args>(args)...);
     for (auto& v : slicing.second)
       v = indexes_[v];
-    return {data_, slicing.first.extents, std::move(slicing.second)};
+    return {data_, slicing.first, std::move(slicing.second)};
   }
 
   template <typename... Args> auto operator()(Args&&... args) const -> detail::slice_request<ind_array<const T, N>, Args...>
@@ -296,7 +296,7 @@ public:
 
     auto slicing = detail::indirect_slicing(descriptor_, rng);
     auto indexes = map_indexes(slicing.second);
-    return {data_, slicing.first.extent, std::move(indexes)};
+    return {data_, slicing.first[0], std::move(indexes)};
   }
 
   auto operator()(typename vector_type::container_type indexes) -> ind_array<T, 1>
@@ -321,7 +321,7 @@ public:
 
     auto slicing = detail::indirect_slicing(descriptor_, rng);
     auto indexes = map_indexes(slicing.second);
-    return {data_, slicing.first.extent, std::move(indexes)};
+    return {data_, slicing.first[0], std::move(indexes)};
   }
 
   auto operator()(typename vector_type::container_type indexes) const -> ind_array<const T, 1>

--- a/jules/array/numeric.hpp
+++ b/jules/array/numeric.hpp
@@ -2,6 +2,7 @@
 #define JULES_ARRAY_NUMERIC_H
 
 #include <jules/array/array.hpp>
+#include <jules/base/const_vector.hpp>
 #include <jules/core/debug.hpp>
 #include <jules/core/meta.hpp>
 #include <jules/core/type.hpp>
@@ -13,7 +14,7 @@
 namespace jules
 {
 
-static inline auto seq(const index_t start, const index_t stop, const distance_t step = 1) -> std::vector<index_t>
+static inline auto seq(const index_t start, const index_t stop, const distance_t step = 1) -> const_vector<index_t>
 {
   DEBUG_ASSERT(step != 0, debug::default_module, debug::level::invalid_argument, "step cannot be zero");
   DEBUG_ASSERT(start <= stop || step < 0, debug::default_module, debug::level::invalid_argument, "stop value is unreachable");
@@ -27,7 +28,7 @@ static inline auto seq(const index_t start, const index_t stop, const distance_t
   for (auto i = start; indexes.size() < size; i += step)
     indexes.push_back(i);
 
-  return indexes;
+  return {std::move(indexes)};
 }
 
 template <typename T, typename A> auto to_vector(A&& array) -> meta::requires_t<vector<T>, Array<std::decay_t<A>>>

--- a/jules/array/ref_array.hpp
+++ b/jules/array/ref_array.hpp
@@ -8,6 +8,7 @@
 #include <jules/array/detail/iterator.hpp>
 #include <jules/array/detail/slicing.hpp>
 #include <jules/array/slice.hpp>
+#include <jules/base/const_vector.hpp>
 #include <jules/core/debug.hpp>
 #include <jules/core/meta.hpp>
 #include <jules/core/range.hpp>
@@ -296,7 +297,7 @@ public:
     return {data_, slicing.first[0], std::move(slicing.second)};
   }
 
-  auto operator()(std::vector<index_t>&& indexes) -> ind_array<T, 1>
+  auto operator()(typename const_vector<index_t>::container_type indexes) -> ind_array<T, 1>
   {
     for (auto& index : indexes)
       index = this->descriptor()(index);
@@ -319,7 +320,7 @@ public:
     return {data_, slicing.first[0], std::move(slicing.second)};
   }
 
-  auto operator()(std::vector<index_t>&& indexes) const -> ind_array<const T, 1>
+  auto operator()(typename const_vector<index_t>::container_type indexes) const -> ind_array<const T, 1>
   {
     for (auto& index : indexes)
       index = this->descriptor()(index);

--- a/jules/base/const_vector.hpp
+++ b/jules/base/const_vector.hpp
@@ -56,9 +56,11 @@ public:
   ///
   /// (2) explicitly by forwarding one parameter to the underlying standard vector.
   ///
-  /// (3) from a initializer list.
+  /// (3) from a standard vector.
   ///
-  /// (4-5) from another vector.
+  /// (4) from a initializer list.
+  ///
+  /// (5-6) from another vector.
   template <typename... Args, typename = std::enable_if_t<(sizeof...(Args) > 1)>>
   const_vector(Args&&... args) : data_{std::make_shared<storage_t>(std::forward<Args>(args)...)}
   {
@@ -66,6 +68,9 @@ public:
 
   /// \group constructors Constructors
   template <typename Arg> explicit const_vector(Arg&& arg) : data_{std::make_shared<storage_t>(std::forward<Arg>(arg))} {}
+
+  /// \group constructors Constructors
+  const_vector(storage_t source) : data_{std::make_shared<storage_t>(std::move(source))} {}
 
   /// \group constructors Constructors
   const_vector(std::initializer_list<value_type> init, const allocator_type& alloc = {})

--- a/jules/base/const_vector.hpp
+++ b/jules/base/const_vector.hpp
@@ -27,25 +27,25 @@ public:
   /// \group member_types Class Types
   using container_type = std::vector<T, Allocator>;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using value_type = T;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using allocator_type = Allocator;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using size_type = typename container_type::size_type;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using difference_type = typename container_type::difference_type;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using const_reference = typename container_type::const_reference;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using const_iterator = typename container_type::const_iterator;
 
-  /// \group member_types Class Types
+  /// \group member_types
   using const_reverse_iterator = typename container_type::const_reverse_iterator;
 
   ~const_vector() = default;
@@ -67,22 +67,22 @@ public:
   {
   }
 
-  /// \group constructors Constructors
+  /// \group constructors
   template <typename Arg> explicit const_vector(Arg&& arg) : data_{std::make_shared<container_type>(std::forward<Arg>(arg))} {}
 
-  /// \group constructors Constructors
+  /// \group constructors
   const_vector(container_type source) : data_{std::make_shared<container_type>(std::move(source))} {}
 
-  /// \group constructors Constructors
+  /// \group constructors
   const_vector(std::initializer_list<value_type> init, const allocator_type& alloc = {})
     : data_{std::make_shared<container_type>(init, alloc)}
   {
   }
 
-  /// \group constructors Constructors
+  /// \group constructors
   const_vector(const const_vector& source) = default;
 
-  /// \group constructors Constructors
+  /// \group constructors
   const_vector(const_vector&& source) noexcept = default;
 
   /// \group assignment Assignment
@@ -112,16 +112,16 @@ public:
   /// (5) Direct access to the underlying array.
   auto at(size_type pos) const -> const_reference { return data_->at(pos); }
 
-  /// \group access Element access
+  /// \group access
   auto operator[](size_type pos) const -> const_reference { return (*data_)[pos]; }
 
-  /// \group access Element access
+  /// \group access
   auto front() const -> const_reference { return data_->front(); }
 
-  /// \group access Element access
+  /// \group access
   auto back() const -> const_reference { return data_->back(); }
 
-  /// \group access Element access
+  /// \group access
   auto data() const -> const value_type* { return data_->data(); }
 
   /// \group iterator Iterators
@@ -135,25 +135,25 @@ public:
   /// (7-8) returns a reverse iterator to the end.
   auto begin() const -> const_iterator { return cbegin(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto cbegin() const -> const_iterator { return data_->cbegin(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto end() const -> const_iterator { return cend(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto cend() const -> const_iterator { return data_->cend(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto rbegin() const -> const_iterator { return crbegin(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto crbegin() const -> const_iterator { return data_->crbegin(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto rend() const -> const_iterator { return crend(); }
 
-  /// \group iterator Iterators
+  /// \group iterator
   auto crend() const -> const_iterator { return data_->crend(); }
 
   /// \group capacity Capacity
@@ -163,8 +163,27 @@ public:
   /// (2) returns the number of elements.
   auto empty() const -> bool { return data_->empty(); }
 
-  /// \group capacity Capacity
+  /// \group capacity
   auto size() const -> size_type { return data_->size(); }
+
+  /// \group comparison Comparison
+  /// Lexicographically compares the values in the vector.
+  auto operator==(const const_vector& other) const -> bool { return *data_ == *other.data_; }
+
+  /// \group comparison
+  auto operator!=(const const_vector& other) const -> bool { return *data_ != *other.data_; }
+
+  /// \group comparison
+  auto operator<(const const_vector& other) const -> bool { return *data_ < *other.data_; }
+
+  /// \group comparison
+  auto operator<=(const const_vector& other) const -> bool { return *data_ <= *other.data_; }
+
+  /// \group comparison
+  auto operator>(const const_vector& other) const -> bool { return *data_ > *other.data_; }
+
+  /// \group comparison
+  auto operator>=(const const_vector& other) const -> bool { return *data_ >= *other.data_; }
 
 private:
   std::shared_ptr<container_type> data_;

--- a/jules/base/const_vector.hpp
+++ b/jules/base/const_vector.hpp
@@ -23,9 +23,10 @@ namespace jules
 /// \notes Unused memory is always freed.
 template <typename T, typename Allocator = typename std::vector<T>::allocator_type> class const_vector
 {
-  using storage_t = std::vector<T, Allocator>;
-
 public:
+  /// \group member_types Class Types
+  using container_type = std::vector<T, Allocator>;
+
   /// \group member_types Class Types
   using value_type = T;
 
@@ -33,19 +34,19 @@ public:
   using allocator_type = Allocator;
 
   /// \group member_types Class Types
-  using size_type = typename storage_t::size_type;
+  using size_type = typename container_type::size_type;
 
   /// \group member_types Class Types
-  using difference_type = typename storage_t::difference_type;
+  using difference_type = typename container_type::difference_type;
 
   /// \group member_types Class Types
-  using const_reference = typename storage_t::const_reference;
+  using const_reference = typename container_type::const_reference;
 
   /// \group member_types Class Types
-  using const_iterator = typename storage_t::const_iterator;
+  using const_iterator = typename container_type::const_iterator;
 
   /// \group member_types Class Types
-  using const_reverse_iterator = typename storage_t::const_reverse_iterator;
+  using const_reverse_iterator = typename container_type::const_reverse_iterator;
 
   ~const_vector() = default;
 
@@ -62,19 +63,19 @@ public:
   ///
   /// (5-6) from another vector.
   template <typename... Args, typename = std::enable_if_t<(sizeof...(Args) > 1)>>
-  const_vector(Args&&... args) : data_{std::make_shared<storage_t>(std::forward<Args>(args)...)}
+  const_vector(Args&&... args) : data_{std::make_shared<container_type>(std::forward<Args>(args)...)}
   {
   }
 
   /// \group constructors Constructors
-  template <typename Arg> explicit const_vector(Arg&& arg) : data_{std::make_shared<storage_t>(std::forward<Arg>(arg))} {}
+  template <typename Arg> explicit const_vector(Arg&& arg) : data_{std::make_shared<container_type>(std::forward<Arg>(arg))} {}
 
   /// \group constructors Constructors
-  const_vector(storage_t source) : data_{std::make_shared<storage_t>(std::move(source))} {}
+  const_vector(container_type source) : data_{std::make_shared<container_type>(std::move(source))} {}
 
   /// \group constructors Constructors
   const_vector(std::initializer_list<value_type> init, const allocator_type& alloc = {})
-    : data_{std::make_shared<storage_t>(init, alloc)}
+    : data_{std::make_shared<container_type>(init, alloc)}
   {
   }
 
@@ -82,7 +83,7 @@ public:
   const_vector(const const_vector& source) = default;
 
   /// \group constructors Constructors
-  const_vector(const_vector&& source) = default;
+  const_vector(const_vector&& source) noexcept = default;
 
   /// \group assignment Assignment
   ///
@@ -92,7 +93,7 @@ public:
   auto operator=(const const_vector& source) -> const_vector& = default;
 
   /// \group assignment Assignment
-  auto operator=(const_vector&& source) -> const_vector& = default;
+  auto operator=(const_vector&& source) noexcept -> const_vector& = default;
 
   /// TODO: assign and get_allocator
 
@@ -166,7 +167,7 @@ public:
   auto size() const -> size_type { return data_->size(); }
 
 private:
-  std::shared_ptr<storage_t> data_;
+  std::shared_ptr<container_type> data_;
 };
 }
 

--- a/jules/base/const_vector.hpp
+++ b/jules/base/const_vector.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2016 Filipe Verri <filipeverri@gmail.com>
+
+// My soul melts away for sorrow;
+//   strengthen me according to your word!
+// Psalm 119:28 (ESV)
+
+#ifndef JULES_BASE_CONST_VECTOR_H
+/// \exclude
+#define JULES_BASE_CONST_VECTOR_H
+
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace jules
+{
+
+/// Sequence container with constant size and elements.
+///
+/// The elements are stored contiguously and cannot be changed after
+/// the vector construction.
+///
+/// \notes Unused memory is always freed.
+template <typename T, typename Allocator = typename std::vector<T>::allocator_type> class const_vector
+{
+  using storage_t = std::vector<T, Allocator>;
+
+public:
+  /// \group member_types Class Types
+  using value_type = T;
+
+  /// \group member_types Class Types
+  using allocator_type = Allocator;
+
+  /// \group member_types Class Types
+  using size_type = typename storage_t::size_type;
+
+  /// \group member_types Class Types
+  using difference_type = typename storage_t::difference_type;
+
+  /// \group member_types Class Types
+  using const_reference = typename storage_t::const_reference;
+
+  /// \group member_types Class Types
+  using const_iterator = typename storage_t::const_iterator;
+
+  /// \group member_types Class Types
+  using const_reverse_iterator = typename storage_t::const_reverse_iterator;
+
+  ~const_vector() = default;
+
+  /// \group constructors Constructors
+  /// Constructs a constant vector:
+  ///
+  /// (1) by forwarding the parameters to the underlying standard vector.
+  ///
+  /// (2) explicitly by forwarding one parameter to the underlying standard vector.
+  ///
+  /// (3) from a initializer list.
+  ///
+  /// (4-5) from another vector.
+  template <typename... Args, typename = std::enable_if_t<(sizeof...(Args) > 1)>>
+  const_vector(Args&&... args) : data_{std::make_shared<storage_t>(std::forward<Args>(args)...)}
+  {
+  }
+
+  /// \group constructors Constructors
+  template <typename Arg> explicit const_vector(Arg&& arg) : data_{std::make_shared<storage_t>(std::forward<Arg>(arg))} {}
+
+  /// \group constructors Constructors
+  const_vector(std::initializer_list<value_type> init, const allocator_type& alloc = {})
+    : data_{std::make_shared<storage_t>(init, alloc)}
+  {
+  }
+
+  /// \group constructors Constructors
+  const_vector(const const_vector& source) = default;
+
+  /// \group constructors Constructors
+  const_vector(const_vector&& source) = default;
+
+  /// \group assignment Assignment
+  ///
+  /// (1) Copy assignment.
+  ///
+  /// (2) Move assignment.
+  auto operator=(const const_vector& source) -> const_vector& = default;
+
+  /// \group assignment Assignment
+  auto operator=(const_vector&& source) -> const_vector& = default;
+
+  /// TODO: assign and get_allocator
+
+  /// \group access Element access
+  ///
+  /// Accessing elements.
+  ///
+  /// (1) Access specified element with bounds checking.
+  ///
+  /// (2) Access specified element.
+  ///
+  /// (3) Access the first element.
+  ///
+  /// (4) Access the last element.
+  ///
+  /// (5) Direct access to the underlying array.
+  auto at(size_type pos) const -> const_reference { return data_->at(pos); }
+
+  /// \group access Element access
+  auto operator[](size_type pos) const -> const_reference { return (*data_)[pos]; }
+
+  /// \group access Element access
+  auto front() const -> const_reference { return data_->front(); }
+
+  /// \group access Element access
+  auto back() const -> const_reference { return data_->back(); }
+
+  /// \group access Element access
+  auto data() const -> const value_type* { return data_->data(); }
+
+  /// \group iterator Iterators
+  ///
+  /// (1-2) returns an iterator to the beginning.
+  ///
+  /// (3-4) returns an iterator to the end.
+  ///
+  /// (5-6) returns a reverse iterator to the beginning.
+  ///
+  /// (7-8) returns a reverse iterator to the end.
+  auto begin() const -> const_iterator { return cbegin(); }
+
+  /// \group iterator Iterators
+  auto cbegin() const -> const_iterator { return data_->cbegin(); }
+
+  /// \group iterator Iterators
+  auto end() const -> const_iterator { return cend(); }
+
+  /// \group iterator Iterators
+  auto cend() const -> const_iterator { return data_->cend(); }
+
+  /// \group iterator Iterators
+  auto rbegin() const -> const_iterator { return crbegin(); }
+
+  /// \group iterator Iterators
+  auto crbegin() const -> const_iterator { return data_->crbegin(); }
+
+  /// \group iterator Iterators
+  auto rend() const -> const_iterator { return crend(); }
+
+  /// \group iterator Iterators
+  auto crend() const -> const_iterator { return data_->crend(); }
+
+  /// \group capacity Capacity
+  ///
+  /// (1) checks whether the container is empty.
+  ///
+  /// (2) returns the number of elements.
+  auto empty() const -> bool { return data_->empty(); }
+
+  /// \group capacity Capacity
+  auto size() const -> size_type { return data_->size(); }
+
+private:
+  std::shared_ptr<storage_t> data_;
+};
+}
+
+#endif // JULES_BASE_CONST_VECTOR_H

--- a/jules/base/numeric.hpp
+++ b/jules/base/numeric.hpp
@@ -3,6 +3,7 @@
 #ifndef JULES_BASE_NUMERIC_H
 #define JULES_BASE_NUMERIC_H
 
+#include <jules/base/const_vector.hpp>
 #include <jules/base/math.hpp>
 #include <jules/core/meta.hpp>
 #include <jules/core/range.hpp>
@@ -267,17 +268,18 @@ template <typename Rng, typename = meta::requires<range::Range<Rng>>> auto freq(
 
 /// \group Which
 ///
-/// Returns a vector with the indexes of the true elements in a `Range` or in the sequence [`first`, `last`).
+/// Returns a const_vector with the indexes of the true elements in a `Range` or in the sequence [`first`, `last`).
 ///
 /// \module Logical
-template <typename Iter, typename Sent, typename = meta::requires<range::Sentinel<Sent, Iter>>> auto which(Iter first, Sent last)
+template <typename Iter, typename Sent, typename = meta::requires<range::Sentinel<Sent, Iter>>>
+auto which(Iter first, Sent last) -> const_vector<index_t>
 {
-  std::vector<index_t> indexes;
+  auto indexes = std::vector<index_t>();
   auto it = first;
   for (auto index = 0ul; it != last; ++index)
     if (*it++)
       indexes.push_back(index);
-  return indexes;
+  return {std::move(indexes)};
 }
 
 /// \group Which

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,8 @@ SRC = array/slice.cpp array/ref_array.cpp array/ind_array.cpp array/array.cpp \
 			dataframe/action.cpp \
 			range/range.cpp random/random.cpp \
 			numeric/numeric.cpp \
-			debug/debug.cpp
+			debug/debug.cpp \
+			const_vector/const_vector.cpp
 
 OBJ := $(SRC:.cpp=.o) test_suite.o
 DEP := $(SRC:.cpp=.d) test_suite.d

--- a/test/const_vector/const_vector.cpp
+++ b/test/const_vector/const_vector.cpp
@@ -1,0 +1,33 @@
+#include "jules/base/const_vector.hpp"
+#include "jules/array/all.hpp"
+
+#include <catch.hpp>
+
+TEST_CASE("Constructing constant vectors", "[const_vector]")
+{
+  using jules::as_vector;
+
+  auto vec = std::vector<int>(5ul);
+
+  // Initializer list
+  auto a = jules::const_vector<int>{1, 2, 3, 4, 5};
+
+  // From a vector
+  auto b = jules::const_vector<int>(vec);
+
+  // With one argument (the size)
+  auto c = jules::const_vector<int>(5ul);
+
+  // With more than one argument
+  auto d = jules::const_vector<int>(5ul, 6);
+
+  CHECK(a.size() == 5u);
+  CHECK(b.size() == 5u);
+  CHECK(c.size() == 5u);
+  CHECK(d.size() == 5u);
+
+  CHECK(all(as_vector(a) == as_vector(1, 2, 3, 4, 5)));
+  CHECK(all(as_vector(b) == as_vector(0, 0, 0, 0, 0)));
+  CHECK(all(as_vector(c) == as_vector(0, 0, 0, 0, 0)));
+  CHECK(all(as_vector(d) == as_vector(6, 6, 6, 6, 6)));
+}

--- a/test/const_vector/const_vector.cpp
+++ b/test/const_vector/const_vector.cpp
@@ -6,28 +6,29 @@
 TEST_CASE("Constructing constant vectors", "[const_vector]")
 {
   using jules::as_vector;
+  using jules::index_t;
 
-  auto vec = std::vector<int>(5ul);
+  auto vec = std::vector<index_t>(5ul);
 
   // Initializer list
-  auto a = jules::const_vector<int>{1, 2, 3, 4, 5};
+  auto a = jules::const_vector<index_t>{1u, 2u, 3u, 4u, 5u};
 
   // From a vector
-  auto b = jules::const_vector<int>(vec);
+  auto b = jules::const_vector<index_t>(vec);
 
   // With one argument (the size)
-  auto c = jules::const_vector<int>(5ul);
+  auto c = jules::const_vector<index_t>(5ul);
 
   // With more than one argument
-  auto d = jules::const_vector<int>(5ul, 6);
+  auto d = jules::const_vector<index_t>(5ul, 6);
 
   CHECK(a.size() == 5u);
   CHECK(b.size() == 5u);
   CHECK(c.size() == 5u);
   CHECK(d.size() == 5u);
 
-  CHECK(all(as_vector(a) == as_vector(1, 2, 3, 4, 5)));
-  CHECK(all(as_vector(b) == as_vector(0, 0, 0, 0, 0)));
-  CHECK(all(as_vector(c) == as_vector(0, 0, 0, 0, 0)));
-  CHECK(all(as_vector(d) == as_vector(6, 6, 6, 6, 6)));
+  CHECK(a == jules::seq(1u, 5u));
+  CHECK(all(as_vector(b) == as_vector(0u, 0u, 0u, 0u, 0u)));
+  CHECK(all(as_vector(c) == 0u));
+  CHECK(all(as_vector(d) == 6u));
 }


### PR DESCRIPTION
- [x] `const_vector` implementation.
- [x] replace in `ind_array`
- [x] utilities returning it
- [x] increase test hits